### PR TITLE
$SCRIPT_ROOT var for api urls

### DIFF
--- a/mhn/static/js/main.js
+++ b/mhn/static/js/main.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
             $('#alert-row').hide();
             $.ajax({
                 type: 'POST',
-                url: '/api/sensor/',
+                url: $SCRIPT_ROOT + '/api/sensor/',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
                 data: JSON.stringify(sensorObj),
                 success: function(resp) {
@@ -51,7 +51,7 @@ $(document).ready(function() {
             var ruleId = $(this).attr('data-rule-id');
 
             requestChange(
-                '/api/rule/' + ruleId + '/',  // URL
+                $SCRIPT_ROOT + '/api/rule/' + ruleId + '/',  // URL
                 checkbox,
                 {is_active: isChecked},  // Data
                 function() {},           // Success
@@ -69,7 +69,7 @@ $(document).ready(function() {
 
             data[fieldName] = input.val();
             requestChange(
-                '/api/rule/' + ruleId + '/',  // URL
+                $SCRIPT_ROOT + '/api/rule/' + ruleId + '/',  // URL
                 input,
                 data,                    // Data
                 function() {},           // Success
@@ -94,12 +94,12 @@ $(document).ready(function() {
 
             $.ajax({
                 type: 'POST',
-                url: '/auth/login/',
+                url: $SCRIPT_ROOT + '/auth/login/',
                 data: JSON.stringify(data),
                 contentType: 'application/json',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
                 success: function() {
-                    window.location.href = '/ui/dashboard/';
+                    window.location.href = $SCRIPT_ROOT + '/ui/dashboard/';
                 },
                 error: function(resp) {
                     $('#alert-text').show();
@@ -111,8 +111,8 @@ $(document).ready(function() {
 
     $('#out-btn').click(function(e) {
         e.preventDefault();
-        $.get('/auth/logout/', function() {
-            window.location.href = '/ui/login/';
+        $.get($SCRIPT_ROOT + '/auth/logout/', function() {
+            window.location.href = $SCRIPT_ROOT + '/ui/login/';
         });
     });
 
@@ -174,7 +174,7 @@ $(document).ready(function() {
             $('#alert-text').hide();
             $.ajax({
                 type: 'POST',
-                url: '/api/rulesources/',
+                url: $SCRIPT_ROOT + '/api/rulesources/',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
                 data: JSON.stringify({
                     name: name,
@@ -197,7 +197,7 @@ $(document).ready(function() {
             $.ajax({
                 type: 'DELETE',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
-                url: '/api/rulesources/' + rsId + '/',
+                url: $SCRIPT_ROOT + '/api/rulesources/' + rsId + '/',
                 success: function() {
                     window.location.reload();
                 },
@@ -217,7 +217,7 @@ $(document).ready(function() {
 
             data[fieldName] = input.val();
             requestChange(
-                '/api/sensor/' + sensorId + '/',  // URL
+                $SCRIPT_ROOT + '/api/sensor/' + sensorId + '/',  // URL
                 input,
                 data,                    // Data
                 function() {},           // Success
@@ -235,7 +235,7 @@ $(document).ready(function() {
             if (d_sensor) {
                 $.ajax({
                     type: 'DELETE',
-                    url: '/api/sensor/' + sensorId + '/',
+                    url: $SCRIPT_ROOT + '/api/sensor/' + sensorId + '/',
                     headers: {'X-CSRFToken': $('#_csrf_token').val()},
                     success: function () {
                         window.location.reload();
@@ -250,7 +250,7 @@ $(document).ready(function() {
                 if (d_events) {
                     $.ajax({
                         type: 'DELETE',
-                        url: '/api/session/' + sensorId + '/',
+                        url: $SCRIPT_ROOT + '/api/session/' + sensorId + '/',
                         headers: {'X-CSRFToken': $('#_csrf_token').val()},
                         success: function () {
                             window.location.reload();
@@ -268,7 +268,7 @@ $(document).ready(function() {
             if (d_events) {
                 $.ajax({
                     type: 'DELETE',
-                    url: '/api/session/' + sensorId + '/',
+                    url: $SCRIPT_ROOT + '/api/session/' + sensorId + '/',
                     headers: {'X-CSRFToken': $('#_csrf_token').val()},
                     success: function () {
                         window.location.reload();
@@ -290,7 +290,7 @@ $(document).ready(function() {
             $('#msg-container').hide();
             $.ajax({
                 type: 'POST',
-                url: '/auth/user/',
+                url: $SCRIPT_ROOT + '/auth/user/',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
                 data: JSON.stringify({
                     email: email,
@@ -317,7 +317,7 @@ $(document).ready(function() {
         $.ajax({
             type: 'DELETE',
             headers: {'X-CSRFToken': $('#_csrf_token').val()},
-            url: '/auth/user/' + userId + '/',
+            url: $SCRIPT_ROOT + '/auth/user/' + userId + '/',
             contentType: 'application/json',
             success: function(resp) {
                 window.location.reload();
@@ -341,7 +341,7 @@ $(document).ready(function() {
 
             $.ajax({
                 type: 'POST',
-                url: '/auth/changepass/',
+                url: $SCRIPT_ROOT + '/auth/changepass/',
                 contentType: 'application/json',
                 headers: {'X-CSRFToken': $('#_csrf_token').val()},
                 data: JSON.stringify({
@@ -351,7 +351,7 @@ $(document).ready(function() {
                     hashstr: hashStr
                 }),
                 success: function(resp) {
-                    window.location = '/';
+                    window.location = $SCRIPT_ROOT + '/';
                 },
                 error: function(resp) {
                     $('#alert-text').removeClass('success').addClass('warning');


### PR DESCRIPTION
Add a $SCRIPT_ROOT variable in front of the api urls for any ajax calls. This affords flexibility in where the api route is hosted (rather than only at default root route) while still maintaining the advantage of static caching. The other change to make this work was made in the base.html template.